### PR TITLE
Support logging.file configuration. Logview will use it's parent folder.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,10 @@ Simple logfile viewer as spring boot actuator endpoint
 
 ##Howto use
 * include library on classpath of spring-boot app
-* configure `logging.path` in spring environment 
-(alternatively - when using custom logging configuration or `logging.file - use `endpoints.logview.path)
+* configure `logging.path`, `logging.file` or `endpoints.logview.path` in spring environment
+    * `logging.file` specifies a custom log file. Logviewer will use it's parent directory.
+    * `logging.path` specifies a log directory and log filename `spring.log`.
+    * `endpoints.logview.path` specifies a directory containing log files in case you use other custom log configurations.
 * endpoint will be available under <management-base>/log
 * to replace default stylesheet links, set property `endpoints.logview.stylesheets` in yml to list of urls
 

--- a/lib/src/main/java/eu/hinsch/spring/boot/actuator/logview/LogViewEndpointAutoconfig.java
+++ b/lib/src/main/java/eu/hinsch/spring/boot/actuator/logview/LogViewEndpointAutoconfig.java
@@ -1,5 +1,6 @@
 package eu.hinsch.spring.boot.actuator.logview;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -7,6 +8,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
+import java.io.File;
 import java.util.List;
 
 import static java.util.Arrays.asList;
@@ -14,16 +16,27 @@ import static java.util.Arrays.asList;
 @Configuration
 public class LogViewEndpointAutoconfig {
 
+    public static final String LOGGING_FILE = "logging.file";
     public static final String LOGGING_PATH = "logging.path";
     public static final String ENDPOINTS_LOGVIEW_PATH = "endpoints.logview.path";
 
+    @ConditionalOnProperty(LOGGING_FILE)
+    @ConditionalOnMissingBean(LogViewEndpoint.class)
+    @Bean
+    public LogViewEndpoint logViewEndpointWithDefaultFile(Environment environment, EndpointConfiguration configuration) {
+        String logDirectory = new File(environment.getRequiredProperty(LOGGING_FILE)).getParentFile().getAbsolutePath();
+        return new LogViewEndpoint(logDirectory, configuration.getStylesheets());
+    }
+
     @ConditionalOnProperty(LOGGING_PATH)
+    @ConditionalOnMissingBean(LogViewEndpoint.class)
     @Bean
     public LogViewEndpoint logViewEndpointWithDefaultPath(Environment environment, EndpointConfiguration configuration) {
         return new LogViewEndpoint(environment.getRequiredProperty(LOGGING_PATH), configuration.getStylesheets());
     }
 
     @ConditionalOnProperty(ENDPOINTS_LOGVIEW_PATH)
+    @ConditionalOnMissingBean(LogViewEndpoint.class)
     @Bean
     public LogViewEndpoint logViewEndpointWithDeviatingPath(Environment environment, EndpointConfiguration configuration) {
         return new LogViewEndpoint(configuration.getPath(), configuration.getStylesheets());

--- a/lib/src/test/java/eu/hinsch/spring/boot/actuator/logview/LogViewEndpointAutoconfigTest.java
+++ b/lib/src/test/java/eu/hinsch/spring/boot/actuator/logview/LogViewEndpointAutoconfigTest.java
@@ -6,8 +6,10 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.core.env.Environment;
 
+import static eu.hinsch.spring.boot.actuator.logview.LogViewEndpointAutoconfig.LOGGING_FILE;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
 
 public class LogViewEndpointAutoconfigTest {
 
@@ -20,6 +22,12 @@ public class LogViewEndpointAutoconfigTest {
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void shouldCreateBeanForDefaultFile() {
+        when(environment.getRequiredProperty(LOGGING_FILE)).thenReturn("./custom.log");
+        assertThat(new LogViewEndpointAutoconfig().logViewEndpointWithDefaultFile(environment, configuration), notNullValue());
     }
 
     @Test

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,7 @@ management:
   context-path: /manage
 logging:
   path: /tmp/log
+#  file: /tmp/log/custom.log
 
 #endpoints:
 #  logview:


### PR DESCRIPTION
1. Support logging.file configuration. Logview will use it's parent folder.
2. Add ConditionalOnMissingBean to avoid multiple beans if by any chance multiple enable conditions have been used.

If both logging.file and logging.path have been configured simultaneously for a Spring Boot application, logging file will take precedence (default Spring Boot handling).